### PR TITLE
ビルド修正

### DIFF
--- a/apk/wasmer/APKBUILD
+++ b/apk/wasmer/APKBUILD
@@ -8,7 +8,7 @@ url="https://wasmer.io/"
 arch="all"
 license="MIT"
 depends=""
-makedepends="rust ncurses-dev libffi-dev"
+makedepends="rust ncurses-dev libffi-dev openssl-dev"
 install=""
 subpackages="$pkgname-wapm"
 source="${pkgname}-${pkgver}.tar.gz::https://github.com/wasmerio/wasmer/archive/refs/tags/${pkgver}.tar.gz"
@@ -16,6 +16,7 @@ builddir="${srcdir}/${pkgname}-${pkgver}"
 
 build() {
 	cd "$builddir"
+	export OPENSSL_NO_VENDOR=2
 	make build-wasmer build-wapm
 }
 

--- a/mgmt/draft.list
+++ b/mgmt/draft.list
@@ -54,4 +54,3 @@ minio      # exists in edge/testing repo
 viddy      # exists in edge/community repo
 nim        # exists in edge/community repo
 pandoc     # exists in edge/testing repo
-wasmer     # tmp

--- a/mgmt/draft.list.aarch64
+++ b/mgmt/draft.list.aarch64
@@ -2,4 +2,3 @@ bazel     # too long build time
 boinc-client
 picoquic
 picotls
-wasmer


### PR DESCRIPTION
- wasmerのビルドがおかしかった問題

その他、wasm関連では、最近入れたwasi-sdkのsysrootがおかしくて、C++のプログラムがコンパイルできない。sysrootのビルド済みバイナリをダウンロードして持ってくれば、ビルドも通るし実行できる。これはどうしようかな…