### PR TITLE
actions deprecate warn

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: setup qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     - name: setup abuild.conf
       shell: bash
       env:
@@ -41,7 +41,7 @@ jobs:
     - name: boot builder
       run: docker-compose -f docker-compose.yml -f ${{ matrix.arch }}.yml up -d builder
     - name: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: cache
         key: ${{ runner.os }}-buildcache-${{ matrix.arch }}-${{ hashFiles('**/APKBUILD') }}

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: setup python
       run: |
         cd mgmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: setup qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     - name: setup abuild.conf
       shell: bash
       env:
@@ -54,7 +54,7 @@ jobs:
     - name: boot builder
       run: docker-compose -f docker-compose.yml -f s3output.yml -f ${{ matrix.arch }}.yml up -d builder
     - name: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ./cache
         key: ${{ runner.os }}-buildcache-${{ matrix.arch }}-${{ hashFiles('**/APKBUILD') }}

--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ./cache
         key: ${{ runner.os }}-buildcache--${{ github.sha }}

--- a/.github/workflows/single-build.yml
+++ b/.github/workflows/single-build.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: setup qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     - name: setup abuild.conf
       shell: bash
       env:

--- a/.github/workflows/update-push.yml
+++ b/.github/workflows/update-push.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: setup abuild.conf
       shell: bash
       env:


### PR DESCRIPTION
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, docker/setup-qemu-action, actions/cache, actions/cache, actions/checkout